### PR TITLE
Use `gcloud app` instead of `gcloud preview app`

### DIFF
--- a/lib/init.sh
+++ b/lib/init.sh
@@ -167,7 +167,7 @@ gcloud_firewall_rules() {
 }
 
 gcloud_appengine() {
-  gcloud_project preview app "$@"
+  gcloud_project app "$@"
 }
 
 gcloud_sql_instances() {


### PR DESCRIPTION
We should use `gcloud app` instead of `gcloud preview app` which will go away soon.
